### PR TITLE
sqlfluff v1.4.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @thewchan
+* @borchero @thewchan

--- a/README.md
+++ b/README.md
@@ -153,5 +153,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@borchero](https://github.com/borchero/)
 * [@thewchan](https://github.com/thewchan/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - click
     - colorama >=0.3
     - diff-cover >=2.5.0
-    - importlib_metadata
+    - importlib_metadata >=1.0.0
     - jinja2
     - pathspec
     - pytest
@@ -67,4 +67,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - borchero
     - thewchan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "sqlfluff" %}
-{% set version = "1.3.2" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/sqlfluff-{{ version }}.tar.gz
-  sha256: 2a291d9c2ff742471c690c4bd1e760a483100fbcba23f330a61e7888f67c0c3f
+  sha256: b19396cc7d7833ebd06773031cc9ffba7ee77c503d8f7e2610db8a6c81f8da29
 
 build:
   noarch: python


### PR DESCRIPTION
This PR updates this package to SQLFluff v1.4.0 which has been released this morning. Unfortunately, the `regro-cf-autotick-bot` has not yet updated the dependency 😅